### PR TITLE
Experimental - Changes compile flags for latency reduction

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -2,7 +2,7 @@
 //#define TESTING				//Enables in-depth debug messages to runtime log (used for debugging)								//By using the testing("message") proc you can create debug-feedback for people with this
 								//uncommented, but not visible in the release version)
 
-#define PRELOAD_RSC	1			/*set to:
+#define PRELOAD_RSC	0			/*set to:
 								0 to allow using external resources or on-demand behaviour;
 								1 to use the default behaviour;
 								2 for preloading absolutely everything;
@@ -47,7 +47,7 @@
 #warn compiling in TESTING mode. testing() debug messages will be visible.
 #endif
 
-#define MIN_COMPILER_VERSION 508
+#define MIN_COMPILER_VERSION 512 // Updated to 512... Should really have 513
 #if DM_VERSION < MIN_COMPILER_VERSION //Update this whenever you need to take advantage of more recent byond features
 #error Your version of BYOND is too out-of-date to compile this project. Go to byond.com/download and update.
 #endif


### PR DESCRIPTION
According to http://www.byond.com/docs/ref/info.html#/client/var/preload_rsc, this enable pre-loads the RSC file from a third party website.  **The RSC file needs to be zipped up, and then uploaded to a site which needs to be written into the  config/external_rsc_urls.txt on the deployed server.** @Swinfernalist .
It maybe likely we need to preload different files instead of the rsc, the handbook is not clear.
If there are major changes to the file, it is advisable to change the file name and update the link.
:cl:
tweak: - Changes to compiler flags
/:cl:
